### PR TITLE
Configuration setting for explicit server IP

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,11 @@
             </intent-filter>
         </activity>
 
+        <service
+            android:name="ChangeSettings"
+            android:exported="true"
+            android:permission="android.permission.WRITE_SETTINGS" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/polygraphene/alvr/ChangeSettings.java
+++ b/app/src/main/java/com/polygraphene/alvr/ChangeSettings.java
@@ -1,0 +1,32 @@
+package com.polygraphene.alvr;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+public class ChangeSettings extends Service {
+    private static final String TAG = "ChangeSettings";
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        PersistentConfig.loadCurrentConfig(this);
+
+        Utils.logi(TAG, () -> "Config setting " + PersistentConfig.KEY_TARGET_SERVERS + " has value: " + PersistentConfig.sTargetServers);
+
+        String targetServers = intent.getStringExtra(PersistentConfig.KEY_TARGET_SERVERS);
+
+        if (targetServers != null) {
+            Utils.logi(TAG, () -> "Setting config setting " + PersistentConfig.KEY_TARGET_SERVERS + " to: " + targetServers);
+            PersistentConfig.sTargetServers = targetServers;
+        }
+
+        PersistentConfig.saveCurrentConfig();
+        stopSelf(startId);
+        return Service.START_NOT_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+}

--- a/app/src/main/java/com/polygraphene/alvr/PersistentConfig.java
+++ b/app/src/main/java/com/polygraphene/alvr/PersistentConfig.java
@@ -10,6 +10,7 @@ public class PersistentConfig {
     private static final String KEY_SERVER_ADDRESS = "serverAddress";
     private static final String KEY_SERVER_PORT = "serverPort";
     private static final String KEY_DEBUG_FLAGS = "debugFlags";
+    public static final String KEY_TARGET_SERVERS = "targetServers";
 
     public static class ConnectionState {
         public String serverAddr;
@@ -18,12 +19,14 @@ public class PersistentConfig {
 
     private static Context sAppContext = null;
     public static long sDebugFlags = 0;
+    public static String sTargetServers = null;
 
     // Save current configs for next startup.
     public static void saveCurrentConfig() {
         SharedPreferences pref = sAppContext.getSharedPreferences("pref", Context.MODE_PRIVATE);
         SharedPreferences.Editor edit = pref.edit();
         edit.putLong(KEY_DEBUG_FLAGS, sDebugFlags);
+        edit.putString(KEY_TARGET_SERVERS, sTargetServers);
         edit.apply();
         Utils.setDebugFlags(sDebugFlags);
     }
@@ -34,6 +37,7 @@ public class PersistentConfig {
 
         SharedPreferences pref = sAppContext.getSharedPreferences("pref", Context.MODE_PRIVATE);
         sDebugFlags = pref.getLong(KEY_DEBUG_FLAGS, 0);
+        sTargetServers = pref.getString(KEY_TARGET_SERVERS, null);
         Utils.setDebugFlags(sDebugFlags);
     }
 

--- a/app/src/main/java/com/polygraphene/alvr/ServerConnection.java
+++ b/app/src/main/java/com/polygraphene/alvr/ServerConnection.java
@@ -138,9 +138,9 @@ class ServerConnection extends ThreadBase
     public void run()
     {
         try {
-            String[] broadcastList = getBroadcastAddressList();
+            String[] targetList = getTargetAddressList();
 
-            mNativeHandle = initializeSocket(HELLO_PORT, PORT, getDeviceName(), broadcastList,
+            mNativeHandle = initializeSocket(HELLO_PORT, PORT, getDeviceName(), targetList,
                     mDeviceDescriptor.mRefreshRates, mDeviceDescriptor.mRenderWidth, mDeviceDescriptor.mRenderHeight, mDeviceDescriptor.mFov,
                     mDeviceDescriptor.mDeviceType, mDeviceDescriptor.mDeviceSubType, mDeviceDescriptor.mDeviceCapabilityFlags,
                     mDeviceDescriptor.mControllerCapabilityFlags
@@ -169,10 +169,18 @@ class ServerConnection extends ThreadBase
         Utils.logi(TAG, () -> "ServerConnection stopped.");
     }
 
-    // List broadcast address from all interfaces except for mobile network.
-    // We should send all broadcast address to use USB tethering or VPN.
-    private String[] getBroadcastAddressList()
+    // List addresses where discovery datagrams will be sent to reach ALVR server.
+    private String[] getTargetAddressList()
     {
+        // List addresses from targetServers setting (if present).
+        if (PersistentConfig.sTargetServers != null && PersistentConfig.sTargetServers.length() > 6) {
+            String[] addrs = PersistentConfig.sTargetServers.split("[^0-9.]+");
+            Utils.logi(TAG, () -> addrs.length + " target server IP addresses were found in config setting " + PersistentConfig.KEY_TARGET_SERVERS + " value: " + PersistentConfig.sTargetServers);
+            return addrs;
+        }
+
+        // List broadcast address from all interfaces except for mobile network.
+        // We should send all broadcast address to use USB tethering or VPN.
         List<String> ret = new ArrayList<>();
         try {
             Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();


### PR DESCRIPTION
This PR allows to specify explicit IP address or ALVR server. 

Server IP can be set from computer - by command line: 
`adb shell am startservice -n "com.polygraphene.alvr/.ChangeSettings" --es "targetServers" "10.10.10.10" `
Multiple IP addresses can be separated by comma (and some other characters). 
Setting can be effectively removed by using any string shorter than 7 characters (e.g. "none") instead of IP address. 

This should provide native support for ALVR server and VR headset on different subnets/networks (e.g. ALVR over VPN and cloud gaming). 

This closes (however - without the new GUI element): https://github.com/polygraphene/ALVRClient/issues/25