### PR TITLE
Application name (ALVR) in launcher

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
     <uses-feature
         android:glEsVersion="0x00030001"
         android:required="true" />
-    <application>
+    <application 
+        android:label="@string/app_name">
 
         <meta-data
             android:name="com.samsung.android.vr.application.mode"


### PR DESCRIPTION
On Oculus Quest list of applications show application name ("ALVR") instead of package name only. 

I am not sure why the `android:label` wasn't present already (as it is a petty default thing). 

P.S. I have tested this on Oculus Quest software version 10.